### PR TITLE
90-add-migrations-to-dashboard-deployment-process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,5 +57,5 @@ EXPOSE 3306
 
 # Run Django Server
 # add in "--log-file=/var/log/djangoApp/gunicorn.log \" when we have logging figured out
-ENTRYPOINT ["/app/bin/gunicorn", "--workers=2", "--bind=0.0.0.0:8000", "poetfolio.wsgi:application"]
+ENTRYPOINT ["/app/entrypoint.prod.sh"]
 

--- a/ekiree_dashboard/entrypoint.prod.sh
+++ b/ekiree_dashboard/entrypoint.prod.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+# Wait for database to be ready
+echo "Waiting for database to be ready..."
+until /app/bin/python manage.py check --database default > /dev/null 2>&1; do
+  echo "MySQL is unavailable - sleeping"
+  sleep 3
+done
+echo "MySQL is up - executing commands"
+  
+/app/bin/python manage.py migrate --noinput
+/app/bin/gunicorn --bind 0.0.0.0:8000 --workers 3 poetfolio.wsgi:application
+


### PR DESCRIPTION
Update Django to run a deploy script instead  of a single run command

This will allow us to add different environmental run times in the future